### PR TITLE
Update maven poms to use the latest jaxb-ri and jaxws-ri

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,13 @@
 	
 	<properties>
 		<context>portal</context>
-		<junit.version>4.10</junit.version>
+		<junit.version>4.12</junit.version>
+		<jaxb.version>2.2.11</jaxb.version>
+		<jaxws.version>2.2.10</jaxws.version>
 		<hibernate-commons-annotations.version>3.3.0.ga</hibernate-commons-annotations.version>
-		<registry-client.version>12.07r1-SNAPSHOT</registry-client.version>
+		<registry-client.version>12.07r2-SNAPSHOT</registry-client.version>
 		<query-parser.version>12.07</query-parser.version>
-		<dictionary.version>12.07r1-SNAPSHOT</dictionary.version>
+		<dictionary.version>12.07r2-SNAPSHOT</dictionary.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 		

--- a/portal.ear/pom.xml
+++ b/portal.ear/pom.xml
@@ -40,9 +40,9 @@
 		<dependency>
 			<groupId>com.sun.xml.ws</groupId>
 			<artifactId>jaxws-rt</artifactId>
-			<version>2.1.7</version>
-			<scope>provided</scope>
+			<version>2.2.10</version>
 		</dependency>
+		
 		<dependency>
 			<groupId>javax.el</groupId>
 			<artifactId>el-api</artifactId>
@@ -90,4 +90,28 @@
 			</plugin>
 		</plugins>
 	</build>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>javax.xml.ws</groupId>
+				<artifactId>jaxws-api</artifactId>
+				<version>${jaxws.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>javax.xml.bind</groupId>
+				<artifactId>jaxb-api</artifactId>
+				<version>${jaxb.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.sun.xml.bind</groupId>
+				<artifactId>jaxb-core</artifactId>
+				<version>${jaxb.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.sun.xml.bind</groupId>
+				<artifactId>jaxb-impl</artifactId>
+				<version>${jaxb.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 </project>

--- a/portal.ejb/pom.xml
+++ b/portal.ejb/pom.xml
@@ -57,12 +57,9 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>com.sun.xml.ws</groupId>
-			<artifactId>jaxws-rt</artifactId>
-			<version>2.1.7</version>
-			<scope>provided</scope>
-		</dependency>
+
+
+		
 		<dependency>
 			<groupId>javax.measure</groupId>
 			<artifactId>jsr-275</artifactId>
@@ -152,4 +149,18 @@
 
 		</plugins>
 	</build>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>javax.xml.bind</groupId>
+				<artifactId>jaxb-api</artifactId>
+				<version>${jaxb.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>javax.xml.ws</groupId>
+				<artifactId>jaxws-api</artifactId>
+				<version>${jaxws.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 </project>


### PR DESCRIPTION
Update maven poms to use the latest jaxb-ri and jaxws-ri, as needed by the registry client library.
Need to strip jaxb and jaxws from Jboss AS 6.1 as shown in the
http://stackoverflow.com/a/13248404