### PR TITLE
When a request is sent to the querystore, its ip address is found in …

### DIFF
--- a/portal.ejb/src/main/java/org/vamdc/portal/session/queryLog/QueryStoreRequestRegistry.java
+++ b/portal.ejb/src/main/java/org/vamdc/portal/session/queryLog/QueryStoreRequestRegistry.java
@@ -49,13 +49,18 @@ public class QueryStoreRequestRegistry {
 	 * @return
 	 */
 	public String getIpAdress() {		
-		String ipAddress = ServletContexts.instance().getRequest()
+		// client and proxies IP are concatenated in this header field : client, proxy1, proxy2 ...
+		String ipAddresses = ServletContexts.instance().getRequest()
 				.getHeader("X-FORWARDED-FOR");
+		String clientAddress = "";
 		
-		if (ipAddress == null) {
-			ipAddress = ServletContexts.instance().getRequest().getRemoteAddr();
+		if (ipAddresses == null) {
+			clientAddress = ServletContexts.instance().getRequest().getRemoteAddr();
+		}else{
+			// keep only original client ip
+			clientAddress = ipAddresses.split(",")[0];			
 		}
-		return ipAddress;
+		return clientAddress;
 	}
 
 }


### PR DESCRIPTION
…X-FORWARDED-FOR header.

However when going through a proxy, addresses of the client and the proxies are concatenated.

This correction keeps only the address of the original client if it is available